### PR TITLE
Retry all create queue failures

### DIFF
--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -168,8 +168,7 @@ class SQS {
         })
         .promise();
     } catch (err) {
-      if (remainingTry > 0 && err.name === 'AWS.SimpleQueueService.NonExistentQueue')
-        return this._createQueue({queueName}, remainingTry - 1);
+      if (remainingTry > 0) return this._createQueue({queueName}, remainingTry - 1);
       log.warning(err.stack);
     }
   }


### PR DESCRIPTION
Fix retries for all failed queue create requests.

why?
Using elasticMQ on my local offline setup resulted in error responses other than "AWS.SimpleQueueService.NonExistentQueue".